### PR TITLE
Fix bn_param typo in FullyConnectedNet.loss()

### DIFF
--- a/deeplearning/classifiers/fc_net.py
+++ b/deeplearning/classifiers/fc_net.py
@@ -203,7 +203,7 @@ class FullyConnectedNet(object):
             self.dropout_param['mode'] = mode
         if self.use_batchnorm:
             for bn_param in self.bn_params:
-                bn_param[mode] = mode
+                bn_param['mode'] = mode
 
         scores = None
         ############################################################################


### PR DESCRIPTION
In `FullyConnectedNet.loss()`, there is a minor typo with regard to setting `bn_param['mode']`

The implication of this bug is that, for `FullyConnectedNet`, batchnorm always behaves in "train" mode, and never enters "test" mode.